### PR TITLE
Allow configuring the scale from the driver manifest (#56)

### DIFF
--- a/inkcut/device/drivers/manifest.enaml
+++ b/inkcut/device/drivers/manifest.enaml
@@ -92,6 +92,9 @@ enamldef DriversManifest(PluginManifest):
             length = '300cm'
             protocols = ['gpgl']
             connections = ['printer']
+            default_config = {
+              'scale': [ 5.64, 5.64 ]
+            }
 
         DeviceDriver:
             manufacturer = 'Ioline'

--- a/inkcut/device/extensions.py
+++ b/inkcut/device/extensions.py
@@ -11,7 +11,7 @@ Created on Jan 16, 2015
 @author: jrm
 """
 import enaml
-from atom.api import Unicode, List, Callable
+from atom.api import Unicode, List, Callable, Dict
 from inkcut.core.declarative import Declarative, d_
 
 DEVICE_DRIVER_POINT = 'inkcut.device.driver'
@@ -19,16 +19,16 @@ DEVICE_PROTOCOL_POINT = 'inkcut.device.protocols'
 DEVICE_TRANSPORT_POINT = 'inkcut.device.transport'
 
 
-def default_device_factory():
+def default_device_factory(default_config):
     """ Generates a device if none is given by the driver.
-    
+
     Returns
     -------
         result: Device
             A configured Device that the application can use.
     """
-    from .plugin import Device
-    return Device()
+    from .plugin import Device, DeviceConfig
+    return Device(config=DeviceConfig(**default_config))
 
 
 def default_device_config_view_factory():
@@ -78,6 +78,8 @@ class DeviceDriver(Declarative):
     #: Config view for editing the config of this device
     config_view = d_(Callable(default=default_device_config_view_factory))
 
+    #: Default settings to contribute to the config when selected
+    default_config = d_(Dict())
 
 class DeviceProtocol(Declarative):
     # Id of the protocol

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -980,7 +980,7 @@ class DevicePlugin(Plugin):
         
         """
         #: Generate the device
-        device = driver.factory()
+        device = driver.factory(driver.default_config)
 
         #: Now set the declaration
         device.declaration = driver


### PR DESCRIPTION
Can this be done in a more generic way? something like this

    for key in default_config.keys():
        device.config[key] = default_config[key]

Didn't work right away since 'config' is not a Dict... should it be?