### PR TITLE
Show Silhouette Portrait in Landscape (#59)

### DIFF
--- a/inkcut/device/drivers/manifest.enaml
+++ b/inkcut/device/drivers/manifest.enaml
@@ -88,8 +88,8 @@ enamldef DriversManifest(PluginManifest):
         DeviceDriver:
             manufacturer = 'Silhouette'
             model = 'Portrait'
-            width = '20cm'
-            length = '300cm'
+            width = '300cm'
+            length = '20cm'
             protocols = ['gpgl']
             connections = ['printer']
 


### PR DESCRIPTION
The Silhouette Portrait has strange orientation/axes. Probably makes most
sense to show it in landscape orientation, keeping the origin at the
bottom-left of the inkcut screen.