### PR TITLE
Support files with viewBox without width or height

### DIFF
--- a/inkcut/core/svg.py
+++ b/inkcut/core/svg.py
@@ -116,6 +116,9 @@ class QtSvgItem(QtGui.QPainterPath):
         in another system
         """
 
+        if value is None:
+            return None
+
         if isinstance(value, (int, float)):
             return value
 


### PR DESCRIPTION
By making parseUnit more forgiving, to for example successfully load the attached svg.

[tb.svg.txt](https://github.com/codelv/inkcut/files/1896544/tb.svg.txt)

