### PR TITLE
Add Vision VE-810XD engraver to manifest.enaml

### DIFF
--- a/inkcut/device/drivers/manifest.enaml
+++ b/inkcut/device/drivers/manifest.enaml
@@ -166,8 +166,8 @@ enamldef DriversManifest(PluginManifest):
         DeviceDriver:
             manufacturer = 'Vision'
             model = ' VE-810 (XD) Engraver'
-            width = '25.4cm'
-            height = '20.32cm'
+            width = '10in'
+            height = '8in'
             protocols = ['hpgl']
             connections = ['serial']
 

--- a/inkcut/device/drivers/manifest.enaml
+++ b/inkcut/device/drivers/manifest.enaml
@@ -162,6 +162,14 @@ enamldef DriversManifest(PluginManifest):
             width = '720cm'
             protocols = ['hpgl', 'dmpl']
             connections = ['serial']
+            
+        DeviceDriver:
+            manufacturer = 'Vision'
+            model = ' VE-810 (XD) Engraver'
+            width = '25.4cm'
+            height = '20.32cm'
+            protocols = ['hpgl']
+            connections = ['serial']
 
         #: Load any drivers from external sources
         Include:


### PR DESCRIPTION
Tested with Vision VE-810XD engraver using serial (19200 rate, hardware handshaking, X-axis mirroring, return to origin). Added to manifest.enaml.