### PR TITLE
Document releasing, installing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ cache: pip
 python:
   - "2.7"
   - "3.6"
+addons:
+  apt:
+    packages:
+    - libcups2-dev
 
 before_script:
   # We need a (fake) display on Travis so I need to start a X server.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -2,6 +2,83 @@
 
 This is documentation is intended for developers wishing to modify or extend Inkcut. 
 
+### Building from source
+
+To build from source use the commands below.
+
+We intend to support both Python 2 (with qt 4) and Python 3 (with qt 5), however using Python 3 is recommended. On 32-bit systems only Python 2 works, since PyQt5 only has a 64-bit package.
+
+#### Python 3 (Recommended)
+
+```bash
+
+virtualenv -p python3 venv
+source venv/bin/activate
+
+# Install lxml
+sudo apt install libxml2-dev libxslt-dev
+
+#: Install inkcut
+pip install .
+
+```
+##### NOTES:
+1. Install commands should be run from the folder Inkcut is cloned/downloaded into using either `cd /path/to/inkcut/folder`
+2. If `pip install . ` gives an error regarding enamlx, you may need to install enamlx, then re-run `pip install . `
+In Ubuntu 16, this can be done by: `pip install git+https://github.com/frmdstryr/enamlx.git`.
+
+#### Python 2
+
+```bash
+
+virtualenv -p python2 venv
+source venv/bin/activate
+
+# Install lxml
+sudo apt install libxml2-dev libxslt-dev
+
+# Only on Python 2 - you must install and link pyqt4
+sudo apt install python-qt4
+
+#: Replace ~/.virtualenvs/cv with venv/ on linux
+ln -s /usr/lib/python2.7/dist-packages/PyQt4/ ~/.virtualenvs/cv/lib/python2.7/site-packages/
+ln -s /usr/lib/python2.7/dist-packages/sip.so ~/.virtualenvs/cv/lib/python2.7/site-packages/
+
+#: Install inkcut
+pip install .
+
+```
+
+
+#### Raspberry pi
+
+```bash
+
+source ~/.profile           #" loads virtual environment profile settings
+workon cv                   #" opens virtual environment cv
+
+# Install lxml
+sudo apt install libxml2-dev libxslt-dev
+
+# Only on Python 2 - you must install and link pyqt4
+sudo apt install python-qt4
+
+#: Replace ~/.virtualenvs/cv with venv/ on linux
+ln -s /usr/lib/python2.7/dist-packages/PyQt4/ ~/.virtualenvs/cv/lib/python2.7/site-packages/
+ln -s /usr/lib/python2.7/dist-packages/sip.so ~/.virtualenvs/cv/lib/python2.7/site-packages/
+
+#: Install inkcut
+pip install .
+
+# On the raspberry pi, install RPI.GPIO (if using the motor control driver)
+pip install RPi.GPIO
+
+# Install zbar (pi only for crop mark registration)
+pip install git+https://github.com/npinchot/zbar.git
+
+```
+
+
 ### Plugins
 
 Inkcut is designed entirely using plugins using enaml's workbench framework. 
@@ -105,10 +182,42 @@ Cd to the folder and
     
     #: Config is in .git/config
 
+### Releasing
 
-#### Donations
+Build:
+
+    :::bash
+    
+    rm -r dist
+    python setup.py sdist
+    python setup.py bdist_wheel --universal
+
+To do a test release:
+
+    :::bash
+    
+    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+Then install and test it (on other machines) with:
+
+    :::bash
+    
+    pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple inkcut
+
+To do the actual release:
+
+    :::bash
+    
+    twine upload dist/*
+
+See also:
+
+* https://packaging.python.org/tutorials/distributing-packages/
+* https://packaging.python.org/guides/using-testpypi/#using-test-pypi
+
+### Donations
 
 I put a lot of work into this project. Initial development started in 2015 and Inkcut was
-completely rewritten 4 times since then improving every iteration.  Please consider
+completely rewritten 4 times since then, improving every iteration.  Please consider
 donating or sponsoring the development of Inkcut [here](https://www.codelv.com/projects/inkcut/support/).
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,113 +1,35 @@
 ### Install
 
-See [original version](#original-version) for installing v1.0 on linux.
+#### Install dependencies
 
-> There are no install packages for v2.0+ as it is an early release and is NOT
-intended for end users. 
+Inkcut requires python. To install inkcut, we use the `pip` tool.
+On Linux and OSX, the cups printer drivers and pyside GUI bindings are required as well.
 
-Developers can install all the dependencies and [build it from source](#building-from-source).
+##### Windows
 
-### Building from source
+This documentation is still pending.
 
-To build from source use the commands below.
+##### Linux
 
-We intend to support both Python 2 (with qt 4) and Python 3 (with qt 5), however using Python 3 is recommended. On 32-bit systems only Python 2 works, since PyQt5 only has a 64-bit package.
+For example on ubuntu:
 
-#### Python 3 (Recommended)
+    :::bash
+    
+    apt-get install python3-pip python3-pyside libcups2-dev
+    pip3 install inkcut
 
-```bash
+##### Raspberry Pi
 
-virtualenv -p python3 venv
-source venv/bin/activate
+This documentation is still pending.
 
-# Install lxml
-sudo apt install libxml2-dev libxslt-dev
+##### OSX
 
-#: Install inkcut
-pip install .
-
-```
-##### NOTES:
-1. Install commands should be run from the folder Inkcut is cloned/downloaded into using either `cd /path/to/inkcut/folder`
-2. If `pip install . ` gives an error regarding enamlx, you may need to install enamlx, then re-run `pip install . `
-In Ubuntu 16, this can be done by: `pip install git+https://github.com/frmdstryr/enamlx.git`.
-
-#### Python 2
-
-```bash
-
-virtualenv -p python2 venv
-source venv/bin/activate
-
-# Install lxml
-sudo apt install libxml2-dev libxslt-dev
-
-# Only on Python 2 - you must install and link pyqt4
-sudo apt install python-qt4
-
-#: Replace ~/.virtualenvs/cv with venv/ on linux
-ln -s /usr/lib/python2.7/dist-packages/PyQt4/ ~/.virtualenvs/cv/lib/python2.7/site-packages/
-ln -s /usr/lib/python2.7/dist-packages/sip.so ~/.virtualenvs/cv/lib/python2.7/site-packages/
-
-#: Install inkcut
-pip install .
-
-```
-
-
-#### Raspberry pi
-
-```bash
-
-source ~/.profile           #" loads virtual environment profile settings
-workon cv                   #" opens virtual environment cv
-
-# Install lxml
-sudo apt install libxml2-dev libxslt-dev
-
-# Only on Python 2 - you must install and link pyqt4
-sudo apt install python-qt4
-
-#: Replace ~/.virtualenvs/cv with venv/ on linux
-ln -s /usr/lib/python2.7/dist-packages/PyQt4/ ~/.virtualenvs/cv/lib/python2.7/site-packages/
-ln -s /usr/lib/python2.7/dist-packages/sip.so ~/.virtualenvs/cv/lib/python2.7/site-packages/
-
-#: Install inkcut
-pip install .
-
-# On the raspberry pi, install RPI.GPIO (if using the motor control driver)
-pip install RPi.GPIO
-
-# Install zbar (pi only for crop mark registration)
-pip install git+https://github.com/npinchot/zbar.git
-
-```
-
-### Original version
-
-To install on linux, simply extract the contents of the package into /home/your_username/.config/inkscape/extensions/
-
-Before starting, ensure that the target machine has the required dependencies
-
-```bash
-pygtk and gtk
-pyserial
-librsvg2-common
-```
-
-
-Assuming the tar.gz archive is saved in your Downloads folder, you can use this command to install it. Replace inkcut-1.0.tar.gz with the archive name.
-
- ```bash
-tar -xzvf Downloads/inkCut-1.0.tar.gz -C .config/inkscape/extensions/
-```
-
-Then restart all instances of inkscape.
-
-
+This documentation is still pending.
 
 ### Running
 
-Run `python main.py` (or `python3 main.py` depending on the system default) or to use the installed version simply run `inkcut`
+To use the installed version simply run `inkcut`
 
+### Installing as Inkscape extension
 
+This documentation is still pending.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -15,7 +15,7 @@ For example on ubuntu:
 
     :::bash
     
-    apt-get install python3-pip python3-pyside libcups2-dev
+    apt-get install python3-pip python3-pyqt5 libcups2-dev
     pip3 install inkcut
 
 ##### Raspberry Pi

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ install_requires = [
      'PyQt5; python_version >= \'3.0\'',
      'qt5reactor; python_version >= \'3.0\'',
 
+     # Linux:
+    'pycups; sys_platform == \'linux2\'',
+    'pycups; sys_platform == \'linux\'',
+
      # Windows:
     'pywin32; sys_platform == \'win32\''
 ];


### PR DESCRIPTION
Moved 'installing from source' to developer page

Uploaded to pypi-test, *seems* OK now, try it with:

  pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple inkcut-rabooftest4

Perhaps another final test before publishing 2.0.4 to the real pypi?