### PR TITLE
Added documental support for Roland CX-300

### DIFF
--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -110,6 +110,7 @@
 |Roland              |Camm-1 CX24                   |Printer   |58        |Unlimited           |Yes    |
 |Roland              |Camm-1 GS-24                  |Printer   |58        |2500                |Yes    |
 |Roland              |Camm-1 Pro CM-300             |Printer   |74        |Unlimited           |No     |
+|Roland              |Camm-1 Pro CX-300             |Printer   |74        |Unlimited           |Yes    |
 |Roland              |CAMM-1 servo GX24             |Printer   |61        |160                 |Yes    |
 |Roland              |Camm1 PNC950                  |Printer   |61        |2500                |Yes    |
 |Roland              |cj-70                         |Serial    |54        |Unlimited           |Yes    |


### PR DESCRIPTION
Hello! Thanks for this amazing project!

Recently I've got a [Roland Camm-1 CX-300](https://www.rolanddga.com/support/products/cutting/camm-1-pro-series-cx-300-30-vinyl-cutter) and being supported by the same driver that supports the CX-24 (documented as supported by Inkcut), I gave it a go and it worked perfectly. I wanted to document it so I am making this small addition.

I was wondering if it wouldn't be beneficial to add a driver for each supported machine for clarity or to specify for each driver which machines it does support.

Let me know if you would like help on it, I would happily do it!

Thanks again :)