### PR TITLE
Added support for Vevor Smart 1 vinyl cutter

### DIFF
--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -184,6 +184,7 @@
 |US Cutter           |vinyl express lynx s60        |Serial    |24        |Unlimited           |Yes    |
 |Vevor               |sk-720                        |Serial    |28        |Unlimited           |Yes    |
 |Vevor               |sk-720                        |Serial    |28        |Unlimited           |No     |
+|Vevor               |Smart 1                       |Parallel  |30        |Unlimited           |Yes    |
 |Vicsign             |630h                          |Serial    |360       |Unlimited           |Yes    |
 |Vicsign             |HS630                         |Serial    |61        |Unlimited           |Yes    |
 |Vicsign             |HW330                         |Printer   |33        |2000                |Yes    |

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -183,7 +183,6 @@
 |US Cutter           |Silver Bullel                 |Printer   |45        |Unlimited           |No     |
 |US Cutter           |vinyl express lynx s60        |Serial    |24        |Unlimited           |Yes    |
 |Vevor               |sk-720                        |Serial    |28        |Unlimited           |Yes    |
-|Vevor               |sk-720                        |Serial    |28        |Unlimited           |No     |
 |Vevor               |Smart 1                       |Parallel  |30        |Unlimited           |Yes    |
 |Vicsign             |630h                          |Serial    |360       |Unlimited           |Yes    |
 |Vicsign             |HS630                         |Serial    |61        |Unlimited           |Yes    |

--- a/inkcut/device/drivers/manifest.enaml
+++ b/inkcut/device/drivers/manifest.enaml
@@ -261,6 +261,16 @@ enamldef DriversManifest(PluginManifest):
             protocols = ['hpgl']
             connections = ['serial','qtserial']
 
+        DeviceDriver:
+            manufacturer = 'Vevor'
+            model = 'Smart 1'
+            width = '30.48cm'
+            length = '34.78cm'
+            protocols = ['hpgl']
+            connections = ['parallel']
+            default_config = {
+            }
+
 #        DeviceDriver:
 #            manufacturer = 'Vision'
 #            model = ' VE-810 (XD) Engraver (configured)'


### PR DESCRIPTION
Just added support for this cutter, 
Tested on the machine directly :)
Note that correct padding to match cutting mat marking are  :
Top & Bottom : 4.30cm
Left & Right : 0cm

I saw a duplicated line in the supported-devices file, I removed it.