### PR TITLE
Issue #174, Issue #69 : Added automatic detection of Inkscape DPI settings

### DIFF
--- a/inkcut/core/svg.py
+++ b/inkcut/core/svg.py
@@ -782,7 +782,7 @@ class QtSvgDoc(QtSvgG):
                 # Not enough version information to make a correct decision,
                 # so we must return None.
                 return None
-        except:
+        except ValueError:
             # Version could not be parsed, assume it's a really old one
             # at 90dpi.
             return None

--- a/inkcut/core/svg.py
+++ b/inkcut/core/svg.py
@@ -25,11 +25,15 @@ from enaml.qt.QtCore import QPointF, QRectF
 ElementType = QPainterPath.ElementType
 EtreeElement = etree._Element
 
+# Inkcut assumes 90DPI for its internal units
+# It's an odd choice, but it's fine as long as it's consistent
+# throughout.
+INKCUT_DPI = 90.0
 
 class QtSvgItem(QPainterPath):
     tag = None
     _nodes = None
-    _uuconv = {'in': 90.0, 'pt': 1.25, 'px': 1, 'mm': 3.5433070866,
+    _uuconv = {'in': INKCUT_DPI, 'pt': 1.25, 'px': 1, 'mm': 3.5433070866,
                'cm': 35.433070866, 'm': 3543.3070866,
                'km': 3543307.0866, 'pc': 15.0, 'yd': 3240, 'ft': 1080}
 
@@ -140,6 +144,17 @@ class QtSvgItem(QPainterPath):
             except KeyError:
                 pass
         return retval
+
+    @staticmethod
+    def getUnit(value):
+        if not value:
+            return None
+        unit = re.compile('(%s)$' % '|'.join(QtSvgItem._uuconv.keys()))
+        u = unit.search(value)
+        if u:
+            return u.string[u.start():u.end()]
+        else:
+            return None
 
     @staticmethod
     def convertToUnit(val, unit='px'):
@@ -685,7 +700,7 @@ class QtSvgSymbol(QtSvgG):
 class QtSvgDoc(QtSvgG):
     tag = "{http://www.w3.org/2000/svg}svg"
 
-    def __init__(self, e, ids=None, parent=False):
+    def __init__(self, e, ids=None, parent=False, dpi_default=96.0, dpi_auto_detect_inkscape=True):
         """
         Creates a QtPainterPath from an SVG document applying all transforms.
 
@@ -698,6 +713,9 @@ class QtSvgDoc(QtSvgG):
             ids: List
                 List of node ids to include. If not given all will be used.
         """
+        self.dpi_default = dpi_default
+        self.dpi_auto_detect_inkscape = dpi_auto_detect_inkscape
+
         is_etree = isinstance(e, EtreeElement)
         self.isParentSvg = parent or not is_etree
         if self.isParentSvg:
@@ -726,29 +744,109 @@ class QtSvgDoc(QtSvgG):
             self.viewBox = QRectF(0, 0, -1, -1)
         super(QtSvgDoc, self).__init__(e, self._nodes)
 
+    # Return the DPI of the inkscape document detected
+    # based on the version information in the SVG
+    # or None if we could not definitely identify it
+    # as an Inkscape document.
+    @staticmethod
+    def dpiDetectFromInkscapeVersionAttribute(e):
+        inkscapeVersionAttribute = e.attrib.get("{http://www.inkscape.org/namespaces/inkscape}version", None)
+        if not inkscapeVersionAttribute:
+            return None
+        inkscapeVersionAttributeSplit = inkscapeVersionAttribute.split(" ")
+        if len(inkscapeVersionAttributeSplit) <= 0:
+            return None
+        inkscapeVersion = inkscapeVersionAttributeSplit[0]
+        inkscapeVersionSplit = inkscapeVersion.split(".")
+        # This try block is just in case we encounter a non-integer
+        # in one of the major or minor versions.  In this case,
+        # we can't reliably detect the DPI based on unit, so we need to
+        # return None.
+        try:
+            # It's at least 2 digits, so pick out the major and minor versions.
+            if (len(inkscapeVersionSplit) >= 2):
+                inkscapeMajorVersion = int(inkscapeVersionSplit[0])
+                inkscapeMinorVersion = int(inkscapeVersionSplit[1])
+                if (inkscapeMajorVersion == 0 and inkscapeMinorVersion < 92):
+                    # Inkscape units are assumed to be 90dpi by older versions of Inkscape
+                    # if they are not explicitly specified, so we scale appropriately
+                    # for older documents.
+                    return 90.0
+                else:
+                    return 96.0
+            elif (len(inkscapeVersionSplit) >= 1):
+                inkscapeMajorVersion = int(inkscapeVersionSplit[0])
+                if (inkscapeMajorVersion >= 1):
+                    return 96.0
+            else:
+                # Not enough version information to make a correct decision,
+                # so we must return None.
+                return None
+        except:
+            # Version could not be parsed, assume it's a really old one
+            # at 90dpi.
+            return None
+        return None
+
     def parseTransform(self, e):
         t = QTransform()
         # transforms don't apply to the root svg element, but we do need to
         # take into account the viewBox there
         if self.isParentSvg:
+            # Establish the default units.
+            # Inkscape assumes 96dpi if units are not explicitly given
+            # because this is specified in the CSS specification.
+
+            # If we're detecting DPI based on Inkscape
+            # defaults for various versions, go ahead and do that.
+            # Otherwise, we'll fall back to the configuration default DPI setting.
+            dpi = self.dpi_default
+            if self.dpi_auto_detect_inkscape:
+                dpi_detected = QtSvgDoc.dpiDetectFromInkscapeVersionAttribute(e)
+                # If we detected something, use it.
+                # otherwise, we just use the system default
+                if dpi_detected:
+                    dpi = dpi_detected
+
+            xunit = QtSvgItem.getUnit(e.attrib.get("width", None))
+            xscale = 1.0
+            if not xunit:
+                xscale = INKCUT_DPI / dpi
+
+            yunit = QtSvgItem.getUnit(e.attrib.get("height", None))
+            yscale = 1.0
+            if not yunit:
+                yscale = INKCUT_DPI / dpi
+
+            # I think perhaps we need to keep this one
+            # because otherwise we won't correctly convert
+            # the units inside the document.
             viewBox = e.attrib.get('viewBox', None)
+            x = 0
+            y = 0
             if viewBox is not None:
+                # If there is a viewbox, we
+                # need to translate the origin, scale,
+                # and then translate it back in order to
+                # preserve the intended structure of the given SVG
+                # document.
                 (x, y, innerWidth, innerHeight) = map(self.parseUnit,
                                                       re.split("[ ,]+",
                                                                viewBox))
-
-                if x != 0 or y != 0:
-                    raise ValueError(
-                        "viewBox '%s' needs to be translated "
-                        "because is not at the origin. "
-                        "See https://github.com/codelv/inkcut/issues/69"
-                        % viewBox)
 
                 outerWidth, outerHeight = map(self.parseUnit,
                                               (e.attrib.get('width', None),
                                                e.attrib.get('height', None)))
                 if outerWidth is not None and outerHeight is not None:
-                    t.scale(outerWidth / innerWidth, outerHeight / innerHeight)
+                    xscale = xscale * outerWidth / innerWidth
+                    yscale = yscale * outerHeight / innerHeight
+
+            # First, translate the origin if the viewbox gives us one.
+            t.translate(-x*xscale, -y*yscale)
+            # Next, scale the drawing to the viewport and DPI because
+            # the remaining elements of the drawing will be based on
+            # the viewbox unit size
+            t.scale(xscale, yscale)
         else:
             x, y = map(self.parseUnit, (e.attrib.get('x', 0),
                                         e.attrib.get('y', 0)))

--- a/inkcut/device/filters/min_line.py
+++ b/inkcut/device/filters/min_line.py
@@ -38,7 +38,7 @@ class MinLineConfig(Model):
     #: Units for display
     units = Enum(*unit_conversions.keys()).tag(config=True)
 
-    # measured in 1/90inch like most other inkcut distances
+    # measured in 1/90inch (1/INKCUT_DPI) like most other inkcut distances
 
     # don't lift the pen for distnaces shorter than this
     min_jump = Float(strict=False).tag(config=True)

--- a/inkcut/device/filters/repeat.py
+++ b/inkcut/device/filters/repeat.py
@@ -22,7 +22,7 @@ from inkcut.core.utils import (
 
 class RepeatConfig(Model):
     steps = Int(1).tag(config=True)
-    # measured in 1/90inch like most other inkcut distances
+    # measured in 1/90inch (1/INKCUT_DPI) like most other inkcut distances
     closed_loop_distance = Float(0.1, strict=False).tag(config=True)
 
 

--- a/inkcut/device/protocols/dmpl.py
+++ b/inkcut/device/protocols/dmpl.py
@@ -9,7 +9,7 @@ Thanks to Lex Wernars
 """
 from atom.api import Enum, Instance, Float
 from inkcut.device.plugin import DeviceProtocol, Model
-
+from inkcut.core.svg import INKCUT_DPI
 
 class DMPLConfig(Model):
     #: Version number
@@ -22,7 +22,7 @@ class DMPLProtocol(DeviceProtocol):
     config = Instance(DMPLConfig, ()).tag(config=True)
 
     #: Output scaling
-    scale = Float(1021/90.0)
+    scale = Float(1021/INKCUT_DPI)
 
     def connection_made(self):
         v = self.config.mode

--- a/inkcut/device/protocols/hpgl.py
+++ b/inkcut/device/protocols/hpgl.py
@@ -7,6 +7,7 @@ Created on Jul 25, 2015
 from atom.api import Instance, Float, Bool, Int
 from inkcut.device.plugin import DeviceProtocol, Model
 from inkcut.core.utils import log
+from inkcut.core.svg import INKCUT_DPI
 
 
 class HPGLConfig(Model):
@@ -15,7 +16,7 @@ class HPGLConfig(Model):
 
 
 class HPGLProtocol(DeviceProtocol):
-    scale = Float(1021/90.0)
+    scale = Float(1021/INKCUT_DPI)
 
     #: Pad option
     config = Instance(HPGLConfig, ()).tag(config=True)

--- a/inkcut/job/models.py
+++ b/inkcut/job/models.py
@@ -245,6 +245,11 @@ class Job(Model):
     def _observe_document(self, change):
         """ Read the document from stdin """
         source = self.document
+        from inkcut.core.workbench import InkcutWorkbench
+        workbench = InkcutWorkbench.instance()
+        plugin = workbench.get_plugin("inkcut.job")
+        self.document_kwargs["dpi_default"] = plugin.dpi_default
+        self.document_kwargs["dpi_auto_detect_inkscape"] = plugin.dpi_auto_detect_inkscape
         if change['type'] == 'update' and source == '-':
             #: Only load from stdin when explicitly changed to it (when doing
             #: open from the cli) otherwise when restoring state this hangs

--- a/inkcut/job/plugin.py
+++ b/inkcut/job/plugin.py
@@ -12,7 +12,7 @@ Created on Jul 12, 2015
 import os
 import sys
 import enaml
-from atom.api import Instance, Enum, List, Str, Int, Float, observe
+from atom.api import Instance, Enum, List, Str, Int, Float, observe, Bool
 from inkcut.core.api import Plugin, unit_conversions, log
 
 from .models import Job, JobError, Material
@@ -47,6 +47,12 @@ class JobPlugin(Plugin):
 
     #: Timeout for optimizing paths
     optimizer_timeout = Float(10, strict=False).tag(config=True)
+
+    # Default DPI setting if no units are specified in document.
+    dpi_default = Float(96, strict=False).tag(config=True)
+
+    # Whether or not to auto-detect DPI settings for Inkscape SVG files.
+    dpi_auto_detect_inkscape = Bool(True).tag(config=True)
 
     def _default_job(self):
         return Job(material=self.material)

--- a/inkcut/job/settings.enaml
+++ b/inkcut/job/settings.enaml
@@ -9,7 +9,8 @@ Created on May 25, 2019
 
 @author: jrm
 """
-from enaml.widgets.api import Container, Form, Label, ObjectCombo
+import textwrap
+from enaml.widgets.api import Container, Form, Label, ObjectCombo, CheckBox
 from enaml.qt.QtWidgets import QApplication
 from enamlx.widgets.api import DoubleSpinBox
 
@@ -23,6 +24,28 @@ enamldef JobSettingsPage(Container):
         ObjectCombo:
             items = list(sorted(model.get_member('units').items))
             selected := model.units
+        Label:
+            text = QApplication.translate("settings", "Default DPI")
+        DoubleSpinBox:
+            suffix = ' dpi'
+            value := model.dpi_default
+            tool_tip = textwrap.dedent("""
+                When importing SVG files, if no units are specified,
+                how many units per inch should be assumed.  Changing
+                this requires closing and re-opening the working document.
+                """).strip()
+        Label:
+            text = QApplication.translate("settings", "Auto-detect Inkscape DPI")
+        CheckBox:
+            text = QApplication.translate("settings", "Enabled")
+            checked := model.dpi_auto_detect_inkscape
+            tool_tip = textwrap.dedent("""
+                Use 96DPI for Inkscape 0.92 and above, or 90dpi for older versions.
+                Inkscape version is detected based on the 'inkscape:version' tag found
+                in the root <svg> element of the document.  Overrides default DPI
+                if Inkscape document is detected.  Changing this requires closing and
+                re-opening the working document.
+                """).strip()
         Label:
             text = QApplication.translate("settings", "Optimizer timeout")
         DoubleSpinBox:

--- a/tests/data/scale/ScaleTest-cm-with-viewbox.svg
+++ b/tests/data/scale/ScaleTest-cm-with-viewbox.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="40cm"
+   height="60cm"
+   viewBox="0 0 400 600"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   sodipodi:docname="ScaleTest-cm-with-viewbox.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.4467452"
+     inkscape:cx="60.826193"
+     inkscape:cy="204.5972"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="1920"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       id="grid1"
+       units="mm"
+       originx="0"
+       originy="0"
+       spacingx="10"
+       spacingy="10"
+       empcolor="#0000ff"
+       empopacity="0.54509804"
+       color="#0000ff"
+       opacity="1"
+       empspacing="10"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.499999;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;paint-order:markers stroke fill"
+       id="rect1"
+       width="20"
+       height="10"
+       x="30"
+       y="50" />
+  </g>
+</svg>

--- a/tests/data/scale/ScaleTest-in-with-viewbox.svg
+++ b/tests/data/scale/ScaleTest-in-with-viewbox.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="15.748032in"
+   height="23.622047in"
+   viewBox="0 0 400 600"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   sodipodi:docname="ScaleTest-in-with-viewbox.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.4467452"
+     inkscape:cx="60.826193"
+     inkscape:cy="204.5972"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="1920"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       id="grid1"
+       units="mm"
+       originx="0"
+       originy="0"
+       spacingx="10"
+       spacingy="10"
+       empcolor="#0000ff"
+       empopacity="0.54509804"
+       color="#0000ff"
+       opacity="1"
+       empspacing="10"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.499999;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;paint-order:markers stroke fill"
+       id="rect1"
+       width="20"
+       height="10"
+       x="30"
+       y="50" />
+  </g>
+</svg>

--- a/tests/data/scale/ScaleTest-in-without-inkscape-tags.svg
+++ b/tests/data/scale/ScaleTest-in-without-inkscape-tags.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="15.748032in"
+   height="23.622047in"
+   viewBox="0 0 400 600"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.499999;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;paint-order:markers stroke fill"
+       id="rect1"
+       width="20"
+       height="10"
+       x="30"
+       y="50" />
+  </g>
+</svg>

--- a/tests/data/scale/ScaleTest-mm-with-viewbox.svg
+++ b/tests/data/scale/ScaleTest-mm-with-viewbox.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400mm"
+   height="600mm"
+   viewBox="0 0 400 600"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   sodipodi:docname="ScaleTest-mm-with-viewbox.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="2.8934903"
+     inkscape:cx="56.333349"
+     inkscape:cy="146.19023"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="1920"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       id="grid1"
+       units="mm"
+       originx="0"
+       originy="0"
+       spacingx="10"
+       spacingy="10"
+       empcolor="#0000ff"
+       empopacity="0.54509804"
+       color="#0000ff"
+       opacity="1"
+       empspacing="10"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.499999;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;paint-order:markers stroke fill"
+       id="rect1"
+       width="20"
+       height="10"
+       x="30"
+       y="50" />
+  </g>
+</svg>

--- a/tests/data/scale/ScaleTest-pt-with-viewbox.svg
+++ b/tests/data/scale/ScaleTest-pt-with-viewbox.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="1133.8583pt"
+   height="1700.7874pt"
+   viewBox="0 0 400 599.99998"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   sodipodi:docname="ScaleTest-pt-with-viewbox.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.4467452"
+     inkscape:cx="60.826193"
+     inkscape:cy="204.5972"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="1920"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       id="grid1"
+       units="mm"
+       originx="0"
+       originy="0"
+       spacingx="10"
+       spacingy="10"
+       empcolor="#0000ff"
+       empopacity="0.54509804"
+       color="#0000ff"
+       opacity="1"
+       empspacing="10"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.499999;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;paint-order:markers stroke fill"
+       id="rect1"
+       width="20"
+       height="10"
+       x="30"
+       y="50" />
+  </g>
+</svg>

--- a/tests/data/scale/ScaleTest-px-with-viewbox-old-inkscape.svg
+++ b/tests/data/scale/ScaleTest-px-with-viewbox-old-inkscape.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="1417.3228125000"
+   height="2125.9843125000"
+   viewBox="0 0 400 600"
+   version="1.1"
+   id="svg1"
+   inkscape:version="0.91.2 (dcaf3e7d9e, 2026-05-05)"
+   sodipodi:docname="ScaleTest-px-with-viewbox.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.4467452"
+     inkscape:cx="60.826193"
+     inkscape:cy="204.5972"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="1920"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       id="grid1"
+       units="mm"
+       originx="0"
+       originy="0"
+       spacingx="10"
+       spacingy="10"
+       empcolor="#0000ff"
+       empopacity="0.54509804"
+       color="#0000ff"
+       opacity="1"
+       empspacing="10"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.499999;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;paint-order:markers stroke fill"
+       id="rect1"
+       width="20"
+       height="10"
+       x="30"
+       y="50" />
+  </g>
+</svg>

--- a/tests/data/scale/ScaleTest-px-with-viewbox.svg
+++ b/tests/data/scale/ScaleTest-px-with-viewbox.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="1511.811"
+   height="2267.7166"
+   viewBox="0 0 400 600"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   sodipodi:docname="ScaleTest-px-with-viewbox.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.4467452"
+     inkscape:cx="60.826193"
+     inkscape:cy="204.5972"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="1920"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       id="grid1"
+       units="mm"
+       originx="0"
+       originy="0"
+       spacingx="10"
+       spacingy="10"
+       empcolor="#0000ff"
+       empopacity="0.54509804"
+       color="#0000ff"
+       opacity="1"
+       empspacing="10"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.499999;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;paint-order:markers stroke fill"
+       id="rect1"
+       width="20"
+       height="10"
+       x="30"
+       y="50" />
+  </g>
+</svg>

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -1,0 +1,92 @@
+"""
+Copyright (c) 2018, Jairus Martin.
+
+Distributed under the terms of the GPL v3 License.
+
+The full license is in the file LICENSE, distributed with this software.
+
+Created on Mar 14, 2018
+
+@author: jrm
+"""
+import os
+import pytest
+from glob import glob
+from inkcut.core.utils import split_painter_path
+from inkcut.core.svg import QtSvgDoc
+
+def mm_to_inkcut_units(dim):
+    # Scale the input (in mm) to Inkcut units
+    return dim*90.0/25.4
+
+# This is just about the limit of precision we can expect
+# for ordinary scale items that would fit on a printer.
+# We may have some rounding error below this precision.
+def close_to(dim, otherdim):
+    return abs(dim-otherdim) < 0.00001
+
+def check_expected_dimensions(doc, x, y, width, height):
+    subpaths = split_painter_path(doc)
+    assert len(subpaths) == 1
+
+    example_rectangle = subpaths[0]
+    example_bounding_rect = example_rectangle.boundingRect()
+    position = example_bounding_rect.topLeft()
+    print(example_bounding_rect)
+    print(position)
+
+    assert close_to(position.x(), mm_to_inkcut_units(x))
+    assert close_to(position.y(), mm_to_inkcut_units(y))
+    assert close_to(example_bounding_rect.width(), mm_to_inkcut_units(width))
+    assert close_to(example_bounding_rect.height(), mm_to_inkcut_units(height))
+
+
+# There are many different ways to express the same
+# SVG drawing with different units.  Here, we test that
+# the same rectangle is expressed in different units, but
+# we still exptect the imported result in terms of
+# INKCUT_DPI units to be preserved.  That is, no matter how
+# you express the units in the SVG document, we can always
+# scale them so that they match 'actual real-world' cutting
+# units.
+
+# In order to do this, we create a rectangle at position 30mm,50mm
+# with size 20mm wide and 10mm high.  We will express this
+# with different units in different documents, but the invariant
+# here is that the imported object in terms of Inkcut units
+# should be the same for all of these documents.
+@pytest.mark.parametrize('path', glob('tests/data/scale/*.svg'))
+def test_scale(path):
+    """ Make sure that we get the same result even if the unit of measure is different in the source documents settings """
+    try:
+        print("Loading document")
+        print(path)
+        doc = QtSvgDoc(path)
+        print("Testing scale")
+
+        check_expected_dimensions(doc, 30, 50, 20, 10)
+
+    except NotImplementedError as e:
+         pytest.skip(str(e))
+
+def test_explicit_dpi_setting_90():
+    """ Test that if we disable detection of inkscape DPI settings, we can still import at the correct scale with the explicit DPI setting """
+    # We want to check that we can manually specify the DPI for
+    # a document without relying on detecting the Inkscape version.
+    doc = QtSvgDoc(
+        "tests/data/scale/ScaleTest-px-with-viewbox-old-inkscape.svg",
+        dpi_default = 90.0,
+        dpi_auto_detect_inkscape = False)
+    print("Just another test")
+    check_expected_dimensions(doc, 30, 50, 20, 10)
+
+def test_explicit_dpi_setting_96():
+    """ Test that if we import with a different DPI setting, it will change the dimensions accordingly """
+    # We want to check that we can manually specify the DPI for
+    # a document without relying on detecting the Inkscape version.
+    doc = QtSvgDoc(
+        "tests/data/scale/ScaleTest-px-with-viewbox-old-inkscape.svg",
+        dpi_default = 96.0,
+        dpi_auto_detect_inkscape = False)
+    print("Just another test")
+    check_expected_dimensions(doc, 30*90/96, 50*90/96, 20*90/96, 10*90/96)

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -1,13 +1,12 @@
 """
-Copyright (c) 2018, Jairus Martin.
+Copyright (c) 2026, The Inkcut Team
 
 Distributed under the terms of the GPL v3 License.
 
 The full license is in the file LICENSE, distributed with this software.
 
-Created on Mar 14, 2018
+Created on June 16, 2026
 
-@author: jrm
 """
 import os
 import pytest


### PR DESCRIPTION
This is intended to address issue #174, #179, and issue #69 

Here, we introduce a "Default DPI" setting wherein the user can specify the DPI to assume for documents that don't have any unit information in the width,height of the <svg> tag.  In addition, we allow detection of Inkscape documents by looking at the version information and assuming 96DPI for recent versions of Inkscape and 90DPI for versions prior to [0.92](https://inkscape.org/release/inkscape-0.92/).

Implementation should be consistent with [Inkscape handling of units](https://wiki.inkscape.org/wiki/Units_In_Inkscape).

In addition, we translate the document by the (unit-scaled) amount specified in the "viewbox" attribute of the root <svg> tag.

Unit tests were also added to confirm that the same rectangle expressed in various unit schemes all result in the correct final dimensions in terms of Inkcut internal units to ensure that the commands sent to the device would result in the same physical cuts/movements.