### PR TITLE
Issue #421 : Added support for clipping the job to the material boundaries

### DIFF
--- a/inkcut/job/filters.py
+++ b/inkcut/job/filters.py
@@ -111,11 +111,11 @@ class Filter(Atom):
 class SvgFilter(Filter):
     pass
 
-# These filters receive a general PainterPath
-# and filter/modify based on geometry rather than
-# SVG structure which is lost when we start manipulating
-# the geometry instead of the SVG/XML structure
-class PathFilter(Filter):
+# These filters receive a general QPainterPath
+# of the entire job after the shapes have been
+# potentially copied, transformed, and otherwise modified
+# by the structure of the job.
+class JobFilter(Filter):
     pass
 
 # This filter clips the geometry to the
@@ -123,7 +123,7 @@ class PathFilter(Filter):
 # settings.  This helps prevent us from accidentally
 # sending the plotter head off the gantry trying to
 # draw geometry that is invalid for the material/device.
-class ClipFilter(PathFilter):
+class ClipFilter(JobFilter):
     @classmethod
     def get_filter_options(cls, job, doc):
         # This filter is always 'enabled' but that
@@ -140,11 +140,16 @@ class ClipFilter(PathFilter):
         if not job.clip_to_plot_area:
             return doc
 
-        # We first get the boundary of the page.
+        # We want to clip to the defined material
+        # boundaries.  We could use job.material.path,
+        # but this doesn't account for the margins and we would
+        # like to make sure that the margins are not cut.
+        # The signs are a bit wierd here because
+        # plus is down instead of up in this context.
         clip_x0 = job.material.padding_left
-        clip_y0 = job.material.padding_bottom
+        clip_y0 = -job.material.padding_bottom
         clip_x1 = job.material.width() - job.material.padding_right
-        clip_y1 = job.material.height() - job.material.padding_top
+        clip_y1 = -job.material.height() + job.material.padding_top
 
         # Then we assemble this as a list of points
         clip_points = [
@@ -168,7 +173,6 @@ class ClipFilter(PathFilter):
         # removing path segments would change
         # the optimizer's results
         clipped = doc.intersected(clip_path)
-
         return clipped
         
 class LayerFilter(SvgFilter):
@@ -257,10 +261,12 @@ class StrokeColorFilter(FillColorFilter):
     style_attr = 'stroke'
 
 
-#: Register all subclasses
-# Note that we distinguish between SVG filters
-# and Path filters because path filters do NOT
-# preserve the SVG tags since they can alter
-# geometry irrespective of the XML structure of the document.
+# SVG Filters apply to the input SVG document
+# and can rely on the SVG/XML structure of the document
+# for things like filtering layers, colors, and styles.
 SVG_FILTERS = {c.type: c for c in find_subclasses(SvgFilter)}
-PATH_FILTERS = {c.type: c for c in find_subclasses(PathFilter)}
+# Job filters apply to the whole document after
+# transformations and copies have been added.
+# These rely only on the geometry/paths (QPainterPath)
+# and do not have access to the SVG/XML structure.
+JOB_FILTERS = {c.type: c for c in find_subclasses(JobFilter)}

--- a/inkcut/job/filters.py
+++ b/inkcut/job/filters.py
@@ -14,6 +14,8 @@ from lxml import etree
 from atom.api import Atom, Str, Instance, Bool, Float
 from enaml.colors import Color, ColorMember, SVG_COLORS
 from inkcut.core.svg import QtSvgDoc, EtreeElement
+from enaml.qt.QtGui import QPainterPath, QPolygonF
+from enaml.qt.QtCore import QPointF
 from inkcut.core.utils import (
     log, find_subclasses, split_painter_path, join_painter_paths
 )
@@ -50,7 +52,7 @@ def get_layer_label(g):
     return g.attrib.get(attr)
 
 
-class JobFilter(Atom):
+class Filter(Atom):
     #: A fixed type name for the UI to extract without using isinstance
     type = ""
 
@@ -101,8 +103,75 @@ class JobFilter(Atom):
         """
         raise NotImplementedError()
 
+# These filters receive an SVG document
+# and produce a filtered version of that
+# same SVG document after filtering/modifying
+# based on the SVG document structure and
+# attributes.
+class SvgFilter(Filter):
+    pass
 
-class LayerFilter(JobFilter):
+# These filters receive a general PainterPath
+# and filter/modify based on geometry rather than
+# SVG structure which is lost when we start manipulating
+# the geometry instead of the SVG/XML structure
+class PathFilter(Filter):
+    pass
+
+# This filter clips the geometry to the
+# bounding-box implied by the Job's material
+# settings.  This helps prevent us from accidentally
+# sending the plotter head off the gantry trying to
+# draw geometry that is invalid for the material/device.
+class ClipFilter(PathFilter):
+    @classmethod
+    def get_filter_options(cls, job, doc):
+        # This filter is always 'enabled' but that
+        # just means it will always run.
+        # It may clip or not clip depending on whether
+        # the job's clip_to_plot_area is true.  This is because
+        # the get_filter_options is only called when
+        # the document is loaded, but not when options
+        # are checked by the user.
+        return [cls(enabled=False)]
+
+    def apply_filter(self, job, doc):
+        # If it's not enabled by the user, we do nothing.
+        if not job.clip_to_plot_area:
+            return doc
+
+        # We first get the boundary of the page.
+        clip_x0 = job.material.padding_left
+        clip_y0 = job.material.padding_bottom
+        clip_x1 = job.material.width() - job.material.padding_right
+        clip_y1 = job.material.height() - job.material.padding_top
+
+        # Then we assemble this as a list of points
+        clip_points = [
+            QPointF(clip_x0, clip_y0),
+            QPointF(clip_x1, clip_y0),
+            QPointF(clip_x1, clip_y1),
+            QPointF(clip_x0, clip_y1),
+            QPointF(clip_x0, clip_y0)
+        ]
+
+        # And finally turn this into a polygon
+        # and then a painter path
+        clip_polygon = QPolygonF(clip_points)
+        clip_path = QPainterPath()
+        clip_path.addPolygon(clip_polygon)
+
+        # Finally, we do the work of clipping
+        # so we can remove the un-needed pieces.
+        # It is important that the clip happen
+        # before the optimize path because
+        # removing path segments would change
+        # the optimizer's results
+        clipped = doc.intersected(clip_path)
+
+        return clipped
+        
+class LayerFilter(SvgFilter):
     type = "layer"
 
     layer = Instance(EtreeElement)
@@ -142,7 +211,7 @@ class LayerFilter(JobFilter):
         return QtSvgDoc(svg, parent=True)
 
 
-class FillColorFilter(JobFilter):
+class FillColorFilter(SvgFilter):
     type = "fill-color"
     style_attr = 'fill'
 
@@ -189,4 +258,9 @@ class StrokeColorFilter(FillColorFilter):
 
 
 #: Register all subclasses
-REGISTRY = {c.type: c for c in find_subclasses(JobFilter)}
+# Note that we distinguish between SVG filters
+# and Path filters because path filters do NOT
+# preserve the SVG tags since they can alter
+# geometry irrespective of the XML structure of the document.
+SVG_FILTERS = {c.type: c for c in find_subclasses(SvgFilter)}
+PATH_FILTERS = {c.type: c for c in find_subclasses(PathFilter)}

--- a/inkcut/job/models.py
+++ b/inkcut/job/models.py
@@ -19,7 +19,7 @@ from atom.api import (
     Dict, Callable, observe
 )
 from contextlib import contextmanager
-from enaml.qt.QtGui import QPainterPath, QTransform
+from enaml.qt.QtGui import QPainterPath, QTransform, QPolygonF
 from enaml.qt.QtCore import QPointF, QRectF
 from enaml.colors import ColorMember
 from inkcut.core.api import Model, AreaBase
@@ -163,6 +163,7 @@ class Job(Model):
     mirror = ContainerList(Bool(), default=[False, False]).tag(config=True)
     align_center = ContainerList(Bool(),
                                  default=[False, False]).tag(config=True)
+    clip_to_plot_area = Bool().tag(config = True)
 
     # Shifting of original file
     auto_shift = Bool(True).tag(config=True, help="shift to start at origin")
@@ -196,7 +197,8 @@ class Job(Model):
     stack_size = ContainerList(Int(), default=[0, 0])
 
     #: Filters to cut only certain items
-    filters = ContainerList(filters.JobFilter)
+    svg_filters = ContainerList(filters.SvgFilter)
+    path_filters = ContainerList(filters.PathFilter)
 
     #: Original path parsed from the source document
     doc = Instance(QtSvgDoc)
@@ -254,13 +256,14 @@ class Job(Model):
             self.doc = self.path = QtSvgDoc(source, **self.document_kwargs)
 
         # Recreate available filters when the document changes
-        self.filters = self._default_filters()
+        self.svg_filters = self._default_filters(filters.SVG_FILTERS)
+        self.path_filters = self._default_filters(filters.PATH_FILTERS)
 
-    def _default_filters(self):
+    def _default_filters(self, filter_list):
         results = []
         if not self.path:
             return results
-        for Filter in filters.REGISTRY.values():
+        for Filter in filter_list.values():
             try:
                 results.extend(Filter.get_filter_options(self, self.path))
             except Exception as e:
@@ -268,16 +271,28 @@ class Job(Model):
                 log.exception(e)
         return results
 
+    def apply_filters(self, filter_list, doc):
+        for f in filter_list:
+            # If the color/layer is NOT enabled, then remove that color/layer
+            if not f.enabled:
+                log.debug("Applying filter {}".format(f))
+                doc = f.apply_filter(self, doc)
+        return doc
+
     def _default_optimized_path(self):
         """ Filter parts of the documen based on the selected layers and colors
 
         """
         doc = self.path
-        for f in self.filters:
-            # If the color/layer is NOT enabled, then remove that color/layer
-            if not f.enabled:
-                log.debug("Applying filter {}".format(f))
-                doc = f.apply_filter(self, doc)
+        # SVG filters need to happen first,
+        # these rely on the SVG structure of
+        # the document.
+        doc = self.apply_filters(self.svg_filters, doc)
+
+        # Path filters come next.  These destroy the 'SVG'
+        # structure and focus on the underlying path
+        # geometry.
+        doc = self.apply_filters(self.path_filters, doc)
 
         # Apply ordering to path
         # this delegates to objects in the ordering module
@@ -287,7 +302,7 @@ class Job(Model):
 
         return doc
 
-    @observe('path', 'order', 'filters')
+    @observe('path', 'order', 'filters', 'clip_to_plot_area')
     def _update_optimized_path(self, change):
         """ Whenever the loaded file (and parsed SVG path) changes update
         it based on the filters from the job.
@@ -374,7 +389,7 @@ class Job(Model):
              'copy_spacing', 'copy_weedline', 'copy_weedline_padding',
              'plot_weedline', 'plot_weedline_padding', 'feed_to_end',
              'feed_after', 'material', 'material.size', 'material.padding',
-             'auto_copies', 'auto_shift')
+             'auto_copies', 'auto_shift', 'clip_to_plot_area')
     def update_document(self, change=None):
         """ Recreate an instance of of the plot using the current settings
 

--- a/inkcut/job/models.py
+++ b/inkcut/job/models.py
@@ -198,7 +198,7 @@ class Job(Model):
 
     #: Filters to cut only certain items
     svg_filters = ContainerList(filters.SvgFilter)
-    path_filters = ContainerList(filters.PathFilter)
+    job_filters = ContainerList(filters.JobFilter)
 
     #: Original path parsed from the source document
     doc = Instance(QtSvgDoc)
@@ -256,20 +256,26 @@ class Job(Model):
             self.doc = self.path = QtSvgDoc(source, **self.document_kwargs)
 
         # Recreate available filters when the document changes
-        self.svg_filters = self._default_filters(filters.SVG_FILTERS)
-        self.path_filters = self._default_filters(filters.PATH_FILTERS)
+        self.svg_filters = self._default_svg_filters()
+        self.job_filters = self._default_job_filters()
 
-    def _default_filters(self, filter_list):
+    def get_filters_from_registry(self, registry):
         results = []
         if not self.path:
             return results
-        for Filter in filter_list.values():
+        for Filter in registry.values():
             try:
                 results.extend(Filter.get_filter_options(self, self.path))
             except Exception as e:
                 log.error("Failed loading filters for: %s" % Filter)
                 log.exception(e)
         return results
+
+    def _default_svg_filters(self):
+        return self.get_filters_from_registry(filters.SVG_FILTERS)
+
+    def _default_job_filters(self):
+        return self.get_filters_from_registry(filters.JOB_FILTERS)
 
     def apply_filters(self, filter_list, doc):
         for f in filter_list:
@@ -289,11 +295,6 @@ class Job(Model):
         # the document.
         doc = self.apply_filters(self.svg_filters, doc)
 
-        # Path filters come next.  These destroy the 'SVG'
-        # structure and focus on the underlying path
-        # geometry.
-        doc = self.apply_filters(self.path_filters, doc)
-
         # Apply ordering to path
         # this delegates to objects in the ordering module
         OrderingHandler = ordering.REGISTRY.get(self.order)
@@ -302,7 +303,7 @@ class Job(Model):
 
         return doc
 
-    @observe('path', 'order', 'filters', 'clip_to_plot_area')
+    @observe('path', 'order', 'svg_filters', 'job_filters', 'clip_to_plot_area')
     def _update_optimized_path(self, change):
         """ Whenever the loaded file (and parsed SVG path) changes update
         it based on the filters from the job.
@@ -370,7 +371,6 @@ class Job(Model):
         # Move to bottom left
         br = bbox.bottomRight()
         path = QTransform.fromTranslate(-br.x(), -br.y()).map(path)
-
         return path
 
     @contextmanager
@@ -490,6 +490,10 @@ class Job(Model):
             0, -self.feed_after + model.boundingRect().top())
                      if self.feed_to_end else QPointF(0, 0))
         model.moveTo(end_point)
+
+        # Apply the job filters to the final result
+        # after copies and transformations have been applied.
+        model = self.apply_filters(self.job_filters, model)
 
         return model
 

--- a/inkcut/job/models.py
+++ b/inkcut/job/models.py
@@ -486,14 +486,14 @@ class Job(Model):
 
         model = QTransform.fromTranslate(tx, ty).map(model)
 
+        # Apply the job filters to the final result
+        # after copies and transformations have been applied.
+        model = self.apply_filters(self.job_filters, model)
+
         end_point = (QPointF(
             0, -self.feed_after + model.boundingRect().top())
                      if self.feed_to_end else QPointF(0, 0))
         model.moveTo(end_point)
-
-        # Apply the job filters to the final result
-        # after copies and transformations have been applied.
-        model = self.apply_filters(self.job_filters, model)
 
         return model
 

--- a/inkcut/job/view.enaml
+++ b/inkcut/job/view.enaml
@@ -335,7 +335,7 @@ enamldef WeedlinesDockItem(DockItem):
 enamldef LayersDockItem(DockItem):
     attr plugin
     attr job: Job << plugin.job
-    attr filters << job.filters if job else []
+    attr filters << job.svg_filters if job else []
 
     title = QApplication.translate("job", "Layers")
     name = 'layers-item'
@@ -505,6 +505,11 @@ enamldef MaterialDockItem(DockItem):
                 text = QApplication.translate("job", 'Align center vertically')
                 icon = load_icon('shape_align_middle')
                 checked := job.align_center[1]
+            CheckBox:
+                text = QApplication.translate("device", "Clip to plot area")
+                icon = load_icon('shape_square_width')
+                checked := job.clip_to_plot_area
+
         Container:
             padding = 0
             constraints = [

--- a/tests/data/clip/clip_test.svg
+++ b/tests/data/clip/clip_test.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   viewBox="0 0 25 25"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   sodipodi:docname="SVGScaleTest.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.50522817"
+     inkscape:cx="396.85039"
+     inkscape:cy="562.12225"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="1920"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.185902;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;paint-order:markers stroke fill"
+       id="rect1"
+       width="25"
+       height="25"
+       x="0"
+       y="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 1.6811204,6.207213 43.06254,5.5606285 40.99347,16.164617 Z"
+       id="path1"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 3.6208743,16.0353 34.268989,19.526858 2.0690707,22.501148 Z"
+       id="path2"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,18 +1,18 @@
 """
-Copyright (c) 2018, Jairus Martin.
+Copyright (c) 2020, The Inkcut Team
 
 Distributed under the terms of the GPL v3 License.
 
 The full license is in the file LICENSE, distributed with this software.
 
-Created on Mar 14, 2018
+Created on June 16, 2026
 
-@author: jrm
 """
 import os
 import pytest
 from glob import glob
 
+from enaml.qt.QtGui import QTransform
 from inkcut.core.svg import QtSvgDoc
 from inkcut.job.filters import ClipFilter
 from inkcut.job.models import Job
@@ -47,17 +47,30 @@ def check_clip_filter(doc, clip):
         job.material.padding[3] = 0
         job.material.size[0] = 25
         job.material.size[1] = 25
-        
+
         filters = ClipFilter.get_filter_options(job, doc)
         clipped_path = filters[0].apply_filter(job, doc)
         
         return clipped_path
-        
+
+def load_job_model(path):
+    doc = QtSvgDoc(path)
+
+    # The job moves the path down to
+    # the bottom corner, so we must
+    # do the same thing the job does to
+    # test that the clip happens in the correct
+    # location.
+    bbox = doc.boundingRect()
+    br = bbox.bottomLeft()
+    doc = QTransform.fromTranslate(-br.x(), -br.y()).map(doc)
+    return doc
+
 def test_disable_clipping():
     """ Check that we can clip an SVG document to the correct size """
     try:
         path = "tests/data/clip/clip_test.svg"
-        doc = QtSvgDoc(path)
+        doc = load_job_model(path)
         clipped_path = check_clip_filter(doc, False)
         original_bbox = doc.boundingRect()
         expect_dimensions(clipped_path, original_bbox.x(), original_bbox.y(), original_bbox.width(), original_bbox.height())
@@ -69,9 +82,9 @@ def test_enable_clipping():
     """ Check that we can clip an SVG document to the correct size """
     try:
         path = "tests/data/clip/clip_test.svg"
-        doc = QtSvgDoc(path)
+        doc = load_job_model(path)
         clipped_path = check_clip_filter(doc, True)
-        expect_dimensions(clipped_path, 0, 0, 25, 25)
+        expect_dimensions(clipped_path, 0, -25, 25, 25)
     except NotImplementedError as e:
          pytest.skip(str(e))
          

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,0 +1,77 @@
+"""
+Copyright (c) 2018, Jairus Martin.
+
+Distributed under the terms of the GPL v3 License.
+
+The full license is in the file LICENSE, distributed with this software.
+
+Created on Mar 14, 2018
+
+@author: jrm
+"""
+import os
+import pytest
+from glob import glob
+
+from inkcut.core.svg import QtSvgDoc
+from inkcut.job.filters import ClipFilter
+from inkcut.job.models import Job
+
+# This is just about the limit of precision we can expect
+# for ordinary scale items that would fit on a printer.
+# We may have some rounding error below this precision.
+def close_to(dim, otherdim):
+    return abs(dim-otherdim) < 0.00001
+
+# Here, we check that our assertions for this test case are covered.
+def expect_dimensions(path, x, y, width, height):
+        clipped_bbox = path.boundingRect()
+        # Check that if we don't clip, we end up with
+        # a bounding rectangle that is the same before and
+        # after the clip.
+        assert close_to(x, clipped_bbox.x())
+        assert close_to(y, clipped_bbox.y())
+        assert close_to(width, clipped_bbox.width())
+        assert close_to(height, clipped_bbox.height())
+
+# Here, we apply the clip filter (or not)
+# depending on which case we're testing.
+def check_clip_filter(doc, clip):
+        job = Job()
+        job.clip_to_plot_area = clip
+
+        # Set the material dimensions
+        job.material.padding[0] = 0
+        job.material.padding[1] = 0
+        job.material.padding[2] = 0
+        job.material.padding[3] = 0
+        job.material.size[0] = 25
+        job.material.size[1] = 25
+        
+        filters = ClipFilter.get_filter_options(job, doc)
+        clipped_path = filters[0].apply_filter(job, doc)
+        
+        return clipped_path
+        
+def test_disable_clipping():
+    """ Check that we can clip an SVG document to the correct size """
+    try:
+        path = "tests/data/clip/clip_test.svg"
+        doc = QtSvgDoc(path)
+        clipped_path = check_clip_filter(doc, False)
+        original_bbox = doc.boundingRect()
+        expect_dimensions(clipped_path, original_bbox.x(), original_bbox.y(), original_bbox.width(), original_bbox.height())
+
+    except NotImplementedError as e:
+         pytest.skip(str(e))
+
+def test_enable_clipping():
+    """ Check that we can clip an SVG document to the correct size """
+    try:
+        path = "tests/data/clip/clip_test.svg"
+        doc = QtSvgDoc(path)
+        clipped_path = check_clip_filter(doc, True)
+        expect_dimensions(clipped_path, 0, 0, 25, 25)
+    except NotImplementedError as e:
+         pytest.skip(str(e))
+         


### PR DESCRIPTION
This relates to issue #421.  This PR adds support for clipping the drawing to the material boundaries as described in the issue.  This helps with ensuring that the plotter head always remains inside a "reasonable" place in the plotter's working area.