### PR TITLE
Device core: reactor-free thread offload, pre-feed, flush barrier, declared-order defaults

### DIFF
--- a/inkcut/core/utils.py
+++ b/inkcut/core/utils.py
@@ -117,6 +117,42 @@ def async_sleep(ms):
     return d
 
 
+def defer_to_thread(func, *args, **kwargs):
+    """Run func in a daemon thread and fire the returned Deferred on the
+    main GUI thread. Unlike twisted's deferToThread this does not need a
+    running twisted reactor: Inkcut installs qreactor but never starts
+    it, so the reactor threadpool never runs and deferToThread'd work
+    would never execute. The app's only live event loop is Qt's, which
+    enaml's deferred_call posts to (thread-safe QEvent post).
+
+    Without an enaml Application (cli/tests) func runs inline and the
+    Deferred fires synchronously.
+    """
+    import threading
+    from enaml.application import Application, deferred_call
+    from twisted.python.failure import Failure
+    d = Deferred()
+    if Application.instance() is None:
+        try:
+            d.callback(func(*args, **kwargs))
+        except Exception:
+            d.errback(Failure())
+        return d
+
+    def worker():
+        try:
+            result = func(*args, **kwargs)
+        except Exception:
+            deferred_call(d.errback, Failure())
+        else:
+            deferred_call(d.callback, result)
+
+    t = threading.Thread(target=worker, name='inkcut-worker')
+    t.daemon = True
+    t.start()
+    return d
+
+
 # -----------------------------------------------------------------------------
 # QPainterPath helpers
 # -----------------------------------------------------------------------------

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -313,6 +313,22 @@ class DeviceConfig(Model):
     #: Use absolute coordinates
     absolute = Bool().tag(config=True)
 
+    #: Feed the material out to the job's full length and back before
+    #: cutting. Pulling stiff media off the roll mid-cut drags the feed
+    #: and can jam the carriage; pre-feeding leaves it hanging free.
+    prefeed = Bool().tag(config=True)
+
+    #: Host-side pre-feed rate in mm/s. Some firmwares (e.g. the KH-870)
+    #: ignore protocol velocity commands, so the pre-feed is paced from
+    #: the host in small steps instead: slow enough that the roll's
+    #: inertia can follow without the grit rollers slipping on the media.
+    prefeed_speed = Float(100.0, strict=False).tag(config=True)
+
+    #: Machine velocity for the cut after a pre-feed. 0 leaves the
+    #: machine at its firmware default: no velocity command is sent
+    #: (the pre-feed is paced host-side, so it cannot leak into the cut).
+    cut_velocity = Int(0).tag(config=True)
+
     #: Device output is spooled by an external service
     #: this will cause the job to run with no delays between commands
     spooled = Bool().tag(config=True)
@@ -546,6 +562,93 @@ class Device(Model):
 
         return path
 
+    def _prefeed_steps(self, model, config, protocol):
+        """ Build the ordered steps for a material pre-feed.
+
+        Feeding the material out to the job's full length and back before
+        cutting leaves it hanging free of the roll, so the cut never has
+        to drag media off a stiff roll (which slips the feed and can jam
+        the carriage).
+
+        The feed rate is paced from the host: the travel is split into
+        small pen-up moves with a delay after each, so the AVERAGE rate
+        matches config.prefeed_speed (mm/s). This is required because
+        some firmwares (e.g. the Anhui Anyu KH-870) ignore protocol
+        velocity commands — a single long move would run at full machine
+        speed, and the roll's inertia makes the grit rollers slip on the
+        media ("spooling"). Protocol velocity commands are still emitted
+        for cutters that do honor them.
+
+        Parameters
+        ----------
+            model: QPainterPath
+                The transformed job model about to be cut.
+            config: DeviceConfig
+                The active device config.
+            protocol: DeviceProtocol
+                The active protocol (used for velocity control when it
+                supports set_velocity).
+
+        Returns
+        -------
+            steps: list of (callable, tuple, float)
+                (callable, args, delay_ms) triples to execute in order;
+                delay_ms is the pause after the step that produces the
+                configured average feed rate.
+
+        """
+        steps = []
+        set_velocity = getattr(protocol, 'set_velocity', None)
+        has_velocity = callable(set_velocity)
+        if not config.prefeed:
+            #: Still honor an explicit cut velocity at job start
+            if config.cut_velocity > 0 and has_velocity:
+                steps.append((set_velocity, (config.cut_velocity,), 0.0))
+            return steps
+        #: The model is still in Qt coordinates here (y <= 0, the flip to
+        #: device space happens in process()), so only the extent is
+        #: meaningful: feed out the bounding box height, not a raw y value.
+        travel = model.boundingRect().height()
+        if travel <= 0:
+            if config.cut_velocity > 0 and has_velocity:
+                steps.append((set_velocity, (config.cut_velocity,), 0.0))
+            return steps
+        #: Only pace via a protocol V command when a velocity is restored
+        #: afterwards (explicit cut velocity, or the job loop applying
+        #: config.speed); otherwise the slow prefeed V would leak into the
+        #: cut on firmwares that honor V.
+        if has_velocity and (config.cut_velocity > 0 or config.speed_enabled):
+            steps.append(
+                (set_velocity, (max(1, int(config.prefeed_speed / 10)),),
+                 0.0))
+        #: Pace from the host: 10mm pen-up steps, each followed by the
+        #: delay that yields prefeed_speed mm/s on average
+        step_px = from_unit(10, 'mm')
+        speed_px = max(1e-6, from_unit(config.prefeed_speed, 'mm'))  # px/s
+        #: Feed from the current origin, not absolute zero: after a
+        #: feed_to_end job the origin sits past the previous cut, and
+        #: rewinding to absolute zero would drag the head back over it.
+        x0, y0 = self.origin[0], self.origin[1]
+        y = y0
+        positions = []
+        while y < y0 + travel:
+            y = min(y + step_px, y0 + travel)
+            positions.append(y)
+        while y > y0:
+            y = max(y - step_px, y0)
+            positions.append(y)
+        prev = y0
+        for pos in positions:
+            delay_ms = abs(pos - prev) / speed_px * 1000.0
+            steps.append((self.move, ([x0, pos, 0],), delay_ms))
+            prev = pos
+        if has_velocity and config.cut_velocity > 0:
+            #: Restore the explicit cut velocity; cut_velocity == 0 means
+            #: firmware default, so nothing is sent (the job loop applies
+            #: config.speed next when speed_enabled).
+            steps.append((set_velocity, (config.cut_velocity,), 0.0))
+        return steps
+
     def init(self, job):
         """ Initialize the job. This should do any final path manipulation
         required by the device (or as specified by the config) and any filters
@@ -664,6 +767,23 @@ class Device(Model):
         cmd = self.config.commands_disconnect
         if cmd:
             yield defer.maybeDeferred(self.connection.write, cmd)
+        #: Let a buffering transport hand off anything still queued
+        #: (e.g. commands_disconnect) before the teardown below drops
+        #: it — but not for a cancelled job, whose queued moves must be
+        #: dropped, and never let a flush error block the disconnect
+        #: (the transport already surfaced it).
+        #: self.job is never cleared after a job ends, so only skip the
+        #: flush while the cancelled job is the ACTIVE one (busy is True
+        #: inside submit's device_busy block) — a later manual
+        #: disconnect must still hand off commands_disconnect.
+        job = self.job
+        flush = getattr(self.connection, 'flush', None)
+        if flush is not None and not (self.busy and job
+                                      and job.info.cancelled):
+            try:
+                yield defer.maybeDeferred(flush)
+            except Exception as e:
+                log.warning("device | flush on disconnect failed: %s" % e)
         yield defer.maybeDeferred(self.connection.disconnect)
 
     @defer.inlineCallbacks
@@ -791,14 +911,54 @@ class Device(Model):
                             yield defer.maybeDeferred(connection.write,
                                                       config.commands_before)
 
-                        self.status = "Working..."
+                        #: Feed the material out and back before cutting
+                        #: so it hangs free of the roll (prevents the cut
+                        #: dragging media off a stiff roll mid-job). The
+                        #: per-step delays pace the feed from the host —
+                        #: some firmwares ignore velocity commands.
+                        for func, fargs, delay_ms in self._prefeed_steps(
+                                model, config, protocol):
+                            #: A jammed or long feed must be stoppable:
+                            #: same pause/cancel/connection checks as the
+                            #: cutting loop below (which also short-circuits
+                            #: the cut if we break out here).
+                            if info.paused:
+                                self.status = "Job paused"
+                                while (info.paused and not info.cancelled
+                                       and connection.connected):
+                                    yield async_sleep(300)  # ms
+                            if info.cancelled:
+                                self.status = "Job cancelled"
+                                info.status = 'cancelled'
+                                break
+                            elif not connection.connected:
+                                self.status = (
+                                    getattr(connection, 'last_error', '')
+                                    or "connection error")
+                                info.status = 'error'
+                                break
+                            yield defer.maybeDeferred(func, *fargs)
+                            if delay_ms > 0:
+                                yield async_sleep(delay_ms)
 
-                        if config.force_enabled:
-                            yield defer.maybeDeferred(
-                                protocol.set_force, config.force)
-                        if config.speed_enabled:
-                            yield defer.maybeDeferred(
-                                protocol.set_velocity, config.speed)
+                        #: If the prefeed broke out (cancel/disconnect),
+                        #: skip the remaining setup — no force/velocity on
+                        #: a cancelled job or a dropped connection; the
+                        #: cutting loop's own checks finish the job with
+                        #: the same flow as a cancel mid-cut.
+                        if not info.cancelled and connection.connected:
+                            self.status = "Working..."
+
+                            if config.force_enabled:
+                                yield defer.maybeDeferred(
+                                    protocol.set_force, config.force)
+                            #: An explicit cut_velocity was already applied
+                            #: as the last prefeed step and takes precedence
+                            #: over the general speed setting.
+                            if (config.speed_enabled
+                                    and not config.cut_velocity > 0):
+                                yield defer.maybeDeferred(
+                                    protocol.set_velocity, config.speed)
 
                         #: For point in the path
                         for (d, cmd, args, kwargs) in self.process(model):
@@ -818,7 +978,12 @@ class Device(Model):
                                 info.status = 'cancelled'
                                 break
                             elif not connection.connected:
-                                self.status = "connection error"
+                                #: Show the transport's own error (e.g.
+                                #: the stalled-mid-transfer guidance)
+                                #: when it recorded one
+                                self.status = (
+                                    getattr(connection, 'last_error', '')
+                                    or "connection error")
                                 info.status = 'error'
                                 break
 
@@ -860,11 +1025,41 @@ class Device(Model):
                             yield defer.maybeDeferred(connection.write,
                                                       config.commands_after)
 
+                        #: The transport may buffer writes on a worker
+                        #: thread (USB): wait until everything queued has
+                        #: been handed to the device before declaring the
+                        #: job done — disconnect() below drops whatever
+                        #: is still queued. Never flush a cancelled or
+                        #: failed job: its queued moves must be dropped.
+                        flush = getattr(connection, 'flush', None)
+                        if (flush is not None and info.status == 'running'
+                                and not info.cancelled):
+                            try:
+                                yield defer.maybeDeferred(
+                                    flush, cancelled=lambda: info.cancelled)
+                            except Exception as e:
+                                if info.cancelled:
+                                    #: the cancel handling below owns it
+                                    log.debug(
+                                        "device | flush cancelled: %s" % e)
+                                else:
+                                    log.error(
+                                        "device | flush failed: %s" % e)
+                                    self.status = str(e)
+                                    info.status = 'error'
+
+                        #: A cancel that lands after the send loop is
+                        #: done (e.g. during the flush drain, which can
+                        #: take minutes) must not become 'complete'
+                        if info.cancelled and info.status == 'running':
+                            self.status = "Job cancelled"
+                            info.status = 'cancelled'
+
                         #: Update stats
                         info.ended = datetime.now()
 
                         #: If not cancelled or errored
-                        if info.status == 'running':
+                        if info.status == 'running' and not info.cancelled:
                             info.done = True
                             info.status = 'complete'
                     except Exception as e:
@@ -1154,14 +1349,28 @@ class DevicePlugin(Plugin):
                 and processing the jobs.
 
         """
-        # Set the protocols based on the declaration
+        # Set the transports based on the declaration. 'disk' and 'usb'
+        # are always offered: predefined drivers predate the raw-USB
+        # transport and would otherwise never expose it. Order by the
+        # driver's declared connections so transports[0] (the default,
+        # see Device._default_connection) is what the driver declares —
+        # not whichever transport happened to register first.
         transports = [t for t in self.transports
-                      if not driver.connections or t.id == 'disk' or
-                      t.id in driver.connections]
+                      if not driver.connections or t.id in ('disk', 'usb')
+                      or t.id in driver.connections]
+        if driver.connections:
+            rank = {tid: i for i, tid in enumerate(driver.connections)}
+            transports.sort(key=lambda t: rank.get(t.id, len(rank)))
 
-        # Set the protocols based on the declaration
+        # Set the protocols based on the declaration, preserving the
+        # driver's declared order: protocols[0] is the default (see
+        # Device._create_default_protocol), and registration order would
+        # otherwise pick e.g. HPGL for drivers listing DMPL first.
         protocols = [p for p in self.protocols
                      if not driver.protocols or p.id in driver.protocols]
+        if driver.protocols:
+            rank = {pid: i for i, pid in enumerate(driver.protocols)}
+            protocols.sort(key=lambda p: rank.get(p.id, len(rank)))
 
         # Generate the device
         return driver.factory(driver, transports, protocols, config)

--- a/inkcut/device/transports/raw/plugin.py
+++ b/inkcut/device/transports/raw/plugin.py
@@ -103,6 +103,35 @@ class RawFdTransport(DeviceTransport):
             log.debug("-- {} | closed by request".format(self.device_path))
             self.connection.loseConnection()
             self.connection = None
+            # connectionLost normally closes the descriptor and clears
+            # self.fd; give it a moment, then close whatever it leaked.
+            # Capture the fd NOW: by the time the callback fires a new
+            # connection may have installed a fresh self.fd.
+            from twisted.internet import reactor
+            reactor.callLater(1.0, self._close_leaked_fd, self.fd)
+        else:
+            self._close_leaked_fd(self.fd)
+        # connectionLost may never fire if the reader side is already gone
+        # (e.g. a FIFO whose consumer died); reset the flag here or the next
+        # connect() is skipped as "already connected" with no connection.
+        self.connected = False
+
+    def _close_leaked_fd(self, fd):
+        """ If connectionLost never fired (dead FIFO reader), the write fd
+        stays open forever, holding the FIFO's writer side hostage. Close
+        only the captured fd, and only while it is still the transport's
+        current one — if connectionLost already handled it (self.fd
+        cleared) or a reconnect installed a new fd, closing here could hit
+        a reused descriptor number. """
+        if fd is None or self.fd is not fd:
+            return
+        self.fd = None
+        try:
+            fd.close()
+            log.debug("-- {} | leaked fd closed".format(self.device_path))
+        except Exception as e:
+            log.warning("-- {} | fd close failed: {}".format(
+                self.device_path, e))
 
     def __repr__(self):
         return self.device_path

--- a/inkcut/job/models.py
+++ b/inkcut/job/models.py
@@ -106,10 +106,15 @@ class JobInfo(Model):
 
     def _default_request_approval(self):
         """ Request approval using the current job """
-        from inkcut.core.workbench import InkcutWorkbench
-        workbench = InkcutWorkbench.instance()
-        plugin = workbench.get_plugin("inkcut.job")
-        return lambda: plugin.request_approval(plugin.job)
+        #: Resolve the plugin lazily — this default is also evaluated by
+        #: __getstate__ (clone/state save), which must work without a
+        #: workbench (deserialization, standalone tests)
+        def request_approval():
+            from inkcut.core.workbench import InkcutWorkbench
+            workbench = InkcutWorkbench.instance()
+            plugin = workbench.get_plugin("inkcut.job")
+            plugin.request_approval(plugin.job)
+        return request_approval
 
     def reset(self):
         """ Reset to initial states"""
@@ -248,10 +253,19 @@ class Job(Model):
         """ Read the document from stdin """
         source = self.document
         from inkcut.core.workbench import InkcutWorkbench
+        #: State restore may set the document before the workbench and
+        #: job plugin exist — fall back to the parser defaults then.
         workbench = InkcutWorkbench.instance()
-        plugin = workbench.get_plugin("inkcut.job")
-        self.document_kwargs["dpi_default"] = plugin.dpi_default
-        self.document_kwargs["dpi_auto_detect_inkscape"] = plugin.dpi_auto_detect_inkscape
+        plugin = None
+        if workbench is not None:
+            try:
+                plugin = workbench.get_plugin("inkcut.job")
+            except Exception:
+                plugin = None
+        if plugin is not None:
+            self.document_kwargs["dpi_default"] = plugin.dpi_default
+            self.document_kwargs["dpi_auto_detect_inkscape"] = \
+                plugin.dpi_auto_detect_inkscape
         if change['type'] == 'update' and source == '-':
             #: Only load from stdin when explicitly changed to it (when doing
             #: open from the cli) otherwise when restoring state this hangs


### PR DESCRIPTION
## Summary

Core device-layer fixes found while getting a VEVOR KH-870 (CH554 CDC, USB `0483:5750`) cutting reliably on macOS — background and full protocol notes in https://github.com/mcmartnor/vevor-cutter-macos and issue #409.

- **`defer_to_thread` helper (core/utils.py):** run blocking work on a daemon thread and fire the Deferred on the GUI thread via enaml's `deferred_call`. Inkcut installs qreactor but never starts it, so `reactor.running` is False in the app and twisted's own `deferToThread` work never executes; this helper is reactor-free. Used by the follow-up USB-transport and PDF-import PRs.
- **Raw fd transport:** close the descriptor when `connectionLost` never fires, so a stale connection can't leak the fd and block reconnects.
- **Job deserialization guards:** `Job._observe_document` and `JobInfo._default_request_approval` no longer crash when the workbench/plugin doesn't exist yet (state restore, standalone use).
- **Material pre-feed + transport flush barrier + declared-order defaults:**
  - Optional pre-feed slowly feeds the material out to the job's length and back before cutting (host-paced; useful for roll media that slips when yanked at full speed). Pause/cancel/connection checks apply between steps.
  - `submit()` waits for an optional transport `flush()` (buffered transports) before declaring a job complete, and skips it for cancelled jobs.
  - Transports and protocols offered for a driver now follow the driver's declared order, so `transports[0]`/`protocols[0]` (the defaults) are what the driver declares instead of registration order.
  - Explicit `cut_velocity` takes precedence over the general speed setting, and `0` means "firmware default — send nothing".

## Testing

Exercised daily on real hardware (VEVOR KH-870 over the native USB transport from the follow-up PR), verified end-to-end on vinyl. Unit tests exist for the pre-feed and flush behavior and can be contributed on request. Upstream defaults are preserved (`feed_to_end` stays off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

