### PR TITLE
Graphic panel: total layout size fields and quick rotate buttons

### DIFF
--- a/inkcut/job/models.py
+++ b/inkcut/job/models.py
@@ -154,6 +154,10 @@ class Job(Model):
 
     # Job properties used for generating the plot
     size = ContainerList(Float(), default=[1, 1])
+
+    #: Size of the final layout (all copies incl. spacing), before the
+    #: trailing feed move. Shown in the UI when copies > 1.
+    final_size = ContainerList(Float(), default=[0, 0])
     scale = ContainerList(Float(), default=[1, 1]).tag(config=True)
     auto_scale = Bool(False).tag(
         config=True, help="automatically scale if it's too big for the area")
@@ -494,6 +498,13 @@ class Job(Model):
         # Apply the job filters to the final result
         # after copies and transformations have been applied.
         model = self.apply_filters(self.job_filters, model)
+
+        if not swap_xy and scale is None:
+            #: Only on the UI update path (device init passes swap/scale
+            #: and would leave device-space numbers here): the whole
+            #: layout's size, excluding the trailing feed move below
+            fbox = model.boundingRect()
+            self.final_size = [fbox.width(), fbox.height()]
 
         end_point = (QPointF(
             0, -self.feed_after + model.boundingRect().top())

--- a/inkcut/job/view.enaml
+++ b/inkcut/job/view.enaml
@@ -146,6 +146,75 @@ enamldef GraphicDockItem(DockItem):
             CheckBox:
                 text = QApplication.translate("job", "Lock aspect ratio")
                 checked := job.lock_scale
+            Conditional:
+                #: Whole layout (all copies incl. spacing) — the per-copy
+                #: spinboxes above don't change when copies are stepped up.
+                #: Editable: typing a total scales the graphic by the
+                #: ratio; spacing is fixed and stacking may reflow, so the
+                #: field re-displays the actual resulting total after the
+                #: layout recomputes.
+                condition << job.copies > 1
+                Label:
+                    text = QApplication.translate("job", "Total Size")
+                Form:
+                    padding = 0
+                    ImageView:
+                        image = load_image('text_letterspacing')
+                    DoubleSpinBox:
+                        value << to_unit(job.final_size[0], plugin.units)
+                        value ::
+                            #: The Qt spinbox rounds to `decimals`; a
+                            #: programmatic update (e.g. copies changed)
+                            #: comes back rounded, and Qt (half-up) and
+                            #: Python (banker's) can disagree by one ulp
+                            #: at halves — so treat anything within one
+                            #: display quantum as "unchanged" or the
+                            #: handler mistakes the echo for the user
+                            #: typing a new total and scales the job.
+                            v = to_unit(job.final_size[0], plugin.units)
+                            changed = abs(v - change['value']) > 1.01 * 10 ** (-self.decimals)
+                            if changed and change['oldvalue'] > 0 and change['value'] > 0:
+                                k = job.scale[0] * change['value']/change['oldvalue']
+                                #: copy: job.scale[0] = k mutates the
+                                #: same list oldvalue would point at
+                                oldvalue = job.scale[:]
+                                try:
+                                    if job.lock_scale:
+                                        job.scale = [k, k]
+                                    else:
+                                        job.scale[0] = k
+                                except Exception as e:
+                                    plugin.workbench.message_critical(title="Does not fit", message=str(e))
+                                    job.scale = oldvalue
+                                    self.value = change['oldvalue']
+                        suffix << " "+plugin.units
+                        minimum = 0.00001
+                        maximum = 99999.9
+                    ImageView:
+                        image = load_image('text_linespacing')
+                    DoubleSpinBox:
+                        value << to_unit(job.final_size[1], plugin.units)
+                        value ::
+                            #: See width field: one display quantum of
+                            #: tolerance to ignore programmatic echoes
+                            v = to_unit(job.final_size[1], plugin.units)
+                            changed = abs(v - change['value']) > 1.01 * 10 ** (-self.decimals)
+                            if changed and change['oldvalue'] > 0 and change['value'] > 0:
+                                k = job.scale[1] * change['value']/change['oldvalue']
+                                #: copy: see width field
+                                oldvalue = job.scale[:]
+                                try:
+                                    if job.lock_scale:
+                                        job.scale = [k, k]
+                                    else:
+                                        job.scale[1] = k
+                                except Exception as e:
+                                    plugin.workbench.message_critical(title="Does not fit", message=str(e))
+                                    job.scale = oldvalue
+                                    self.value = change['oldvalue']
+                        suffix << " "+plugin.units
+                        minimum = 0.00001
+                        maximum = 99999.9
             #CheckBox:
             #    text = 'Scale to fit'
             #    checked := job.auto_scale
@@ -216,6 +285,39 @@ enamldef GraphicDockItem(DockItem):
                     minimum = -180
                     wrapping = True
                     single_step = 15
+            Container:
+                #: Illustrator-style quick rotate; wraps into [-180, 180]
+                padding = 0
+                constraints = [hbox(rl, rr, r180, spacer)]
+                PushButton: rl:
+                    text = '90° ' + QApplication.translate("job", "left")
+                    icon = load_icon('shape_rotate_anticlockwise')
+                    clicked ::
+                        oldvalue = job.rotation
+                        try:
+                            job.rotation = ((job.rotation + 90 + 180) % 360) - 180
+                        except Exception as e:
+                            plugin.workbench.message_critical(title="Does not fit", message=str(e))
+                            job.rotation = oldvalue
+                PushButton: rr:
+                    text = '90° ' + QApplication.translate("job", "right")
+                    icon = load_icon('shape_rotate_clockwise')
+                    clicked ::
+                        oldvalue = job.rotation
+                        try:
+                            job.rotation = ((job.rotation - 90 + 180) % 360) - 180
+                        except Exception as e:
+                            plugin.workbench.message_critical(title="Does not fit", message=str(e))
+                            job.rotation = oldvalue
+                PushButton: r180:
+                    text = '180°'
+                    clicked ::
+                        oldvalue = job.rotation
+                        try:
+                            job.rotation = ((job.rotation + 180 + 180) % 360) - 180
+                        except Exception as e:
+                            plugin.workbench.message_critical(title="Does not fit", message=str(e))
+                            job.rotation = oldvalue
             CheckBox:
                 text = QApplication.translate("job", "Rotate to save space")
                 checked := job.auto_rotate


### PR DESCRIPTION
## Summary

Two small Graphic-panel quality-of-life additions:

- **Total layout size:** when copies > 1, editable width/height fields show the size of the whole layout (all copies incl. spacing, excluding the trailing feed move) — typing a total scales the graphic proportionally. The value guards compare at spinbox display precision so programmatic layout updates can't be mistaken for user edits.
- **Quick rotate buttons:** 90° left / 90° right / 180° under the rotation field (Illustrator-style), normalized into [-180°, 180°] with the same does-not-fit handling as the spinbox.

Standalone; no dependency on the other PRs.

## Testing

In daily use on macOS; the layout math is exercised by unit tests that can be contributed on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

